### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfiles/python-flask-pymongo/Dockerfile
+++ b/Dockerfiles/python-flask-pymongo/Dockerfile
@@ -2,7 +2,7 @@ FROM       ubuntu:latest
 MAINTAINER Ivo Camargo <ivo.camargo@neoway.com.br>
 
 # Update apt-get sources AND install Python-dve
-RUN apt-get update && sudo apt-get install -y build-essential python-dev 
+RUN apt-get update && apt-get install -y build-essential python-dev 
 RUN apt-get install -y python-setuptools
 RUN apt-get install -y python-pip
 RUN apt-get install -y nano


### PR DESCRIPTION
Remove sudo from line 5, not required and causes following error:

/bin/sh: 1: sudo: not found
ERROR: Service 'flask' failed to build: The command '/bin/sh -c apt-get update && sudo apt-get install -y build-essential python-dev' returned a non-zero code: 127